### PR TITLE
Update types references in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git@github.com:darthtrevino/relay-cursor-paging.git"
   },
   "main": "lib/index.js",
-  "typings": "index.d.ts",
+  "typings": "lib/index.d.ts",
   "scripts": {
     "clean": "rimraf lib",
     "jest": "jest",


### PR DESCRIPTION
The reference to this package's types are at the root, but as they really live inside a folder it isn't quite hooked up correctly.

<img width="358" alt="screen shot 2017-10-06 at 10 40 15 pm" src="https://user-images.githubusercontent.com/49038/31304068-629e2626-aae7-11e7-8f80-7e9dcbc20da7.png">
